### PR TITLE
[FIXED] -- Made minor changes to the query parameters in the Instagram token refresh API for long-lived access tokens.

### DIFF
--- a/instagram_profile/client.py
+++ b/instagram_profile/client.py
@@ -121,7 +121,7 @@ def convert_auth_code_to_long_lived_token(auth_code: str):
 
 def refresh_long_lived_access_token(long_lived_access_token):
     r = requests.get(settings.INSTAGRAM_REFRESH_ACCESS_TOKEN_URL, params={
-        'grant_type': 'ig_exchange_token',
+        'grant_type': 'ig_refresh_token',
         'access_token': long_lived_access_token,
     })
     return _parse_access_token_response(r, error_msg='Error refreshing long lived access token')


### PR DESCRIPTION
# Made minor changes to the query parameters in the Instagram token refresh API for long-lived access tokens.

1. Previously, the 'grant_type' query parameter in the Instagram token refresh API request was set to 'ig_exchange_token'.
2. This commit corrects the query parameter to 'ig_refresh_token,' aligning it with the correct functionality for refreshing long-lived access tokens.
3. This change ensures that the django Instagram profile library properly refreshes access tokens for long-term usage.